### PR TITLE
Refactor: Use hourly open price for sell orders in backtest

### DIFF
--- a/tests/test_backtesting_engine.py
+++ b/tests/test_backtesting_engine.py
@@ -43,159 +43,367 @@ class TestBacktestingEngineBehavior(unittest.TestCase): # Renamed for broader sc
 
         # Sample OHLCV data: 3 full days of hourly data + 1 more hour = 73 hours
         # Start from 2023-01-01 00:00:00 UTC up to 2023-01-04 00:00:00 UTC
-        # Start from 2023-01-01 00:00:00 UTC up to 2023-01-04 00:00:00 UTC
-        timestamps = pd.date_range(start='2023-01-01 00:00:00', end='2023-01-04 00:00:00', freq='h', tz='UTC')
-        self.sample_ohlcv_data = pd.DataFrame({
-            'timestamp': timestamps,
-            'open': [100 + i*0.1 for i in range(len(timestamps))],
-            'high': [105 + i*0.1 + (i%3)*0.2 for i in range(len(timestamps))],
-            'low': [95 + i*0.1 - (i%3)*0.2 for i in range(len(timestamps))],
-            'close': [100 + i*0.1 + ( (i%5)-2 )*0.1 for i in range(len(timestamps))],
-            'volume': [1000 + i*10 for i in range(len(timestamps))]
+        self.sample_daily_ohlcv_data = pd.DataFrame({
+            'timestamp': pd.to_datetime(['2023-01-01', '2023-01-02', '2023-01-03', '2023-01-04'], utc=True),
+            'open': [100, 110, 120, 130],
+            'high': [105, 115, 125, 135], # Ensure breakout can occur on 2023-01-02
+            'low': [95, 105, 115, 125],
+            'close': [102, 112, 122, 132], # Daily close for 2023-01-02 is 112
+            'volume': [1000, 1000, 1000, 1000]
         })
-        self.mock_data_fetcher.fetch_ohlcv.return_value = self.sample_ohlcv_data
+
+        # Hourly data setup
+        # Buy decision time: 2023-01-02 10:00:00 UTC+8 (which is 2023-01-02 02:00:00 UTC)
+        # We need an hourly candle at or before 02:00:00 UTC on Jan 2nd.
+        self.hourly_close_price_for_buy = 111.75 # Specific price to check for the BUY order
+
+        hourly_timestamps_jan1 = pd.date_range(start='2023-01-01 00:00:00', end='2023-01-01 23:00:00', freq='h', tz='UTC')
+        hourly_timestamps_jan2_list = [
+            pd.Timestamp('2023-01-02 00:00:00', tz='UTC'),
+            pd.Timestamp('2023-01-02 01:00:00', tz='UTC'),
+            pd.Timestamp('2023-01-02 02:00:00', tz='UTC'), # This candle will be used for the buy price
+            pd.Timestamp('2023-01-02 03:00:00', tz='UTC')
+        ]
+        hourly_timestamps_jan2 = pd.DatetimeIndex(hourly_timestamps_jan2_list)
+
+        hourly_timestamps_jan3 = pd.date_range(start='2023-01-03 00:00:00', end='2023-01-03 23:00:00', freq='h', tz='UTC')
+        hourly_timestamps_jan4 = pd.date_range(start='2023-01-04 00:00:00', end='2023-01-04 00:00:00', freq='h', tz='UTC') # Just one candle for the end date
+
+        all_hourly_timestamps = hourly_timestamps_jan1.union(hourly_timestamps_jan2).union(hourly_timestamps_jan3).union(hourly_timestamps_jan4)
+
+        self.sample_hourly_ohlcv_data = pd.DataFrame({
+            'timestamp': all_hourly_timestamps,
+            # Simple ascending values for other columns, will adjust specific close for buy
+            'open': [100 + i*0.01 for i in range(len(all_hourly_timestamps))],
+            'high': [100.05 + i*0.01 for i in range(len(all_hourly_timestamps))],
+            'low': [99.95 + i*0.01 for i in range(len(all_hourly_timestamps))],
+            'close': [100 + i*0.01 for i in range(len(all_hourly_timestamps))],
+            'volume': [100 + i for i in range(len(all_hourly_timestamps))]
+        })
+
+        # Set the specific close for the target buy candle (2023-01-02 02:00:00 UTC)
+        target_hourly_buy_candle_time = pd.Timestamp('2023-01-02 02:00:00', tz='UTC')
+        self.sample_hourly_ohlcv_data.loc[self.sample_hourly_ohlcv_data['timestamp'] == target_hourly_buy_candle_time, 'close'] = self.hourly_close_price_for_buy
+
+        # Set the specific open for the target sell candle (2023-01-03 02:00:00 UTC)
+        self.hourly_open_price_for_sell = 120.25
+        target_hourly_sell_candle_time = pd.Timestamp('2023-01-03 02:00:00', tz='UTC')
+        if target_hourly_sell_candle_time in self.sample_hourly_ohlcv_data['timestamp'].values:
+            self.sample_hourly_ohlcv_data.loc[self.sample_hourly_ohlcv_data['timestamp'] == target_hourly_sell_candle_time, 'open'] = self.hourly_open_price_for_sell
+        else:
+            # Add the row if it doesn't exist (e.g. if hourly_timestamps_jan3 didn't include 02:00 explicitly)
+            new_sell_row = pd.DataFrame([{
+                'timestamp': target_hourly_sell_candle_time,
+                'open': self.hourly_open_price_for_sell,
+                'high': self.sample_hourly_ohlcv_data['high'].mean(), # Placeholder
+                'low': self.sample_hourly_ohlcv_data['low'].mean(),   # Placeholder
+                'close': self.sample_hourly_ohlcv_data['close'].mean(),# Placeholder
+                'volume': self.sample_hourly_ohlcv_data['volume'].mean()# Placeholder
+            }])
+            self.sample_hourly_ohlcv_data = pd.concat([self.sample_hourly_ohlcv_data, new_sell_row])
+
+        # Ensure data is sorted by timestamp if any manual additions happened out of order
+        self.sample_hourly_ohlcv_data = self.sample_hourly_ohlcv_data.sort_values('timestamp').reset_index(drop=True)
+
+        def mock_fetch_ohlcv_se(symbol, timeframe, since, limit=None, params=None):
+            # print(f"Mock fetch_ohlcv called with: timeframe={timeframe}, since={since}") # For debugging tests
+            if timeframe == '1d':
+                # Filter daily data by since, similar to how engine might if 'since' was for daily
+                daily_data_copy = self.sample_daily_ohlcv_data.copy()
+                if since is not None:
+                    since_ts = pd.Timestamp(since, unit='ms', tz='UTC')
+                    daily_data_copy = daily_data_copy[daily_data_copy['timestamp'] >= since_ts.normalize()] # Compare date part for daily
+                return daily_data_copy
+            elif timeframe == '1h':
+                hourly_data_copy = self.sample_hourly_ohlcv_data.copy()
+                if since is not None:
+                    since_ts = pd.Timestamp(since, unit='ms', tz='UTC')
+                    hourly_data_copy = hourly_data_copy[hourly_data_copy['timestamp'] >= since_ts]
+                return hourly_data_copy
+            return pd.DataFrame()
+
+        self.mock_data_fetcher.fetch_ohlcv.side_effect = mock_fetch_ohlcv_se
+        # self.mock_data_fetcher.fetch_ohlcv.return_value is now managed by side_effect
 
     @patch(PATCH_PATH_SG)
     @patch('owl.backtesting_engine.engine.logging')
-    def test_buy_and_sell_trade_execution_holding_period(self, mock_logging, MockSignalGenerator):
+    def test_buy_and_sell_trade_execution_with_hourly_buy_price(self, mock_logging, MockSignalGenerator):
         mock_sg_instance = MockSignalGenerator.return_value
+        self.sample_config['strategy']['n_day_high_period'] = 1 # Breakout on 2023-01-02 (115 > 105)
+        self.sample_config['backtesting']['timeframe'] = '1d' # Ensure engine knows main timeframe is daily
 
         # --- Scenario Setup ---
-        # Config: holding_period_days = 1. Buy window 09:00-17:00. Sell at 10:00 Beijing time.
-        # Buy on 2023-01-02 (Monday) at 10:00 Beijing time (02:00 UTC).
-        # Expected sell: Day of buy + 1 day (holding_period_days) = Day D+1. Sell occurs on Day D+1 at 10:00.
-        # So, if buy is Mon 10:00, hold Tue, sell Wed 10:00. (days_passed will be 2)
-        # Corrected understanding: days_passed >= holding_period_days (1) means sell on Tue 10:00.
+        # Buy on 2023-01-02. Daily high is 115. Previous day (2023-01-01) high is 105. Breakout.
+        # Buy decision time: 2023-01-02 10:00:00 UTC+8 (which is 02:00:00 UTC)
+        # Expected hourly candle for price: 2023-01-02 02:00:00 UTC, close = self.hourly_close_price_for_buy (111.75)
+        # Daily candle timestamp for trade record: 2023-01-02 00:00:00 UTC
 
-        buy_day_utc = pd.Timestamp('2023-01-02 00:00:00', tz='UTC') # Monday
-        buy_hour_utc8 = 10 # Within 09:00-17:00 buy window
-        buy_trigger_utc_timestamp = buy_day_utc.replace(hour=2) # 02:00 UTC is 10:00 Beijing Time
+        buy_trigger_daily_ts_utc = pd.Timestamp('2023-01-02 00:00:00', tz='UTC')
+        buy_decision_time_utc8_hour = 10 # 10:00 UTC+8
+        # expected_hourly_pickup_time_utc = pd.Timestamp(f'2023-01-02 {buy_decision_time_utc8_hour-8:02d}:00:00', tz='UTC') # 02:00 UTC for the hourly candle
 
-        # Expected sell day: holding_period_days = 1. Buy on day X. Sell on day X+1 at 10:00.
-        # Buy on Jan 2 (Monday). Sell on Jan 3 (Tuesday) at 10:00 Beijing Time.
-        sell_day_utc = pd.Timestamp('2023-01-03 00:00:00', tz='UTC') # Tuesday
-        sell_trigger_utc_timestamp = sell_day_utc.replace(hour=2) # 02:00 UTC is 10:00 Beijing Time
+        # Expected sell day: holding_period_days = 1. Buy on Jan 2. Sell on Jan 3 at 10:00 Beijing Time.
+        sell_day_utc = pd.Timestamp('2023-01-03 00:00:00', tz='UTC')
+        sell_trigger_utc_timestamp = sell_day_utc.replace(hour=2) # 02:00 UTC is 10:00 Beijing Time (for sell)
 
-        def check_breakout_side_effect(*args, **kwargs):
-            dt_utc8 = kwargs.get('current_datetime_utc8')
-            # Trigger BUY at the specific hour on the buy day
-            if dt_utc8.year == buy_trigger_utc_timestamp.year and \
-               dt_utc8.month == buy_trigger_utc_timestamp.month and \
-               dt_utc8.day == buy_trigger_utc_timestamp.day and \
-               dt_utc8.hour == buy_hour_utc8: # buy_hour_utc8 = 10
+        def check_breakout_side_effect_for_hourly(*args, **kwargs):
+            daily_ohlcv_data_arg = kwargs.get('daily_ohlcv_data')
+            current_day_high_arg = kwargs.get('current_day_high')
+            dt_utc8_arg = kwargs.get('current_datetime_utc8')
+
+            # Trigger BUY on 2023-01-02 at 10:00 UTC+8
+            if dt_utc8_arg.date() == pd.Timestamp('2023-01-02').date() and \
+               dt_utc8_arg.hour == buy_decision_time_utc8_hour:
+
+                # Verify data passed to check_breakout_signal is daily
+                # Check if mostly daily: diff between timestamps should be >= 1 day, or only 1 record
+                is_daily_data = True
+                if len(daily_ohlcv_data_arg) > 1:
+                    min_diff = daily_ohlcv_data_arg['timestamp'].diff().min()
+                    if not (min_diff >= pd.Timedelta(days=1) - pd.Timedelta(seconds=1)): # allow for minor precision issues
+                        is_daily_data = False
+                self.assertTrue(is_daily_data, "Data passed to check_breakout_signal doesn't appear to be daily.")
+
+                expected_high_for_buy_day = self.sample_daily_ohlcv_data[
+                    self.sample_daily_ohlcv_data['timestamp'] == buy_trigger_daily_ts_utc
+                ]['high'].iloc[0]
+                self.assertEqual(current_day_high_arg, expected_high_for_buy_day)
                 return "BUY"
             return None
 
-        mock_sg_instance.check_breakout_signal.side_effect = check_breakout_side_effect
-        # check_breakdown_signal no longer exists on the instance
+        mock_sg_instance.check_breakout_signal.side_effect = check_breakout_side_effect_for_hourly
 
         engine = BacktestingEngine(
             config=self.sample_config,
             data_fetcher=self.mock_data_fetcher,
-            signal_generator=None
+            signal_generator=None # Engine will create its own, which is mocked by PATCH_PATH_SG
         )
 
         with patch.object(engine, '_simulate_order', wraps=engine._simulate_order) as spy_simulate_order:
             engine.run_backtest()
 
-        # Check SignalGenerator was instantiated correctly (with new, reduced signature)
-        MockSignalGenerator.assert_called_once_with(
-            n_day_high_period=self.sample_config['strategy']['n_day_high_period'],
-            buy_window_start_time_str=self.sample_config['strategy']['buy_window_start_time'],
-            buy_window_end_time_str=self.sample_config['strategy']['buy_window_end_time']
-            # No m_day_low_period or sell_window args
-        )
+        # --- Assertions for Data Fetching ---
+        fetch_calls = self.mock_data_fetcher.fetch_ohlcv.call_args_list
+        self.assertEqual(len(fetch_calls), 2, "fetch_ohlcv should be called twice (daily and hourly)")
+        self.assertEqual(fetch_calls[0].kwargs['timeframe'], '1d')
+        self.assertEqual(fetch_calls[1].kwargs['timeframe'], '1h')
+        # Check if 'since' was passed correctly (example for hourly)
+        self.assertIsNotNone(fetch_calls[1].kwargs['since'], "'since' should be passed for hourly fetch")
+
 
         # --- Assertions for BUY order ---
         buy_order_call = None
-        for call_args_list_item in spy_simulate_order.call_args_list:
-            if call_args_list_item.kwargs.get('order_type') == 'BUY':
-                buy_order_call = call_args_list_item
+        for call_item in spy_simulate_order.call_args_list:
+            if call_item.kwargs.get('order_type') == 'BUY':
+                buy_order_call = call_item
                 break
         self.assertIsNotNone(buy_order_call, "BUY order was not simulated")
 
         buy_kwargs = buy_order_call.kwargs
-        self.assertEqual(buy_kwargs['timestamp'], buy_trigger_utc_timestamp)
-        buy_price_actual = self.sample_ohlcv_data[self.sample_ohlcv_data['timestamp'] == buy_trigger_utc_timestamp]['close'].iloc[0]
-        self.assertEqual(buy_kwargs['price'], buy_price_actual)
+        self.assertEqual(buy_kwargs['timestamp'], buy_trigger_daily_ts_utc, "BUY order timestamp should be the daily candle's timestamp")
+        self.assertEqual(buy_kwargs['price'], self.hourly_close_price_for_buy, "BUY order price should be the specific hourly close")
 
-        # Check portfolio state after BUY
-        self.assertEqual(engine.portfolio['asset_entry_timestamp_utc'], buy_trigger_utc_timestamp)
-        self.assertEqual(engine.portfolio['asset_entry_price'], buy_price_actual)
-        qty_bought = buy_kwargs['quantity'] # Store for sell check
+        qty_bought = buy_kwargs['quantity']
 
         # --- Assertions for SELL order (Holding Period) ---
         sell_order_call = None
-        for call_args_list_item in spy_simulate_order.call_args_list:
-            if call_args_list_item.kwargs.get('order_type') == 'SELL':
-                sell_order_call = call_args_list_item
+        for call_item in spy_simulate_order.call_args_list:
+            if call_item.kwargs.get('order_type') == 'SELL':
+                sell_order_call = call_item
                 break
         self.assertIsNotNone(sell_order_call, "SELL order was not simulated due to holding period")
 
         sell_kwargs = sell_order_call.kwargs
-        self.assertEqual(sell_kwargs['timestamp'], sell_trigger_utc_timestamp)
-        sell_price_actual = self.sample_ohlcv_data[self.sample_ohlcv_data['timestamp'] == sell_trigger_utc_timestamp]['close'].iloc[0]
-        self.assertEqual(sell_kwargs['price'], sell_price_actual)
+
+        # sell_trigger_utc_timestamp was defined as Jan 3, 02:00 UTC (for the 10:00 UTC+8 check)
+        # The actual order timestamp in _simulate_order should be the beginning of that daily candle
+        expected_sell_order_daily_ts = pd.Timestamp('2023-01-03 00:00:00', tz='UTC') # This is self.sample_daily_ohlcv_data.iloc[2]['timestamp']
+
+        self.assertEqual(sell_kwargs['timestamp'], expected_sell_order_daily_ts, "SELL order timestamp should be the daily candle's timestamp for the sell day")
+        self.assertEqual(sell_kwargs['price'], self.hourly_open_price_for_sell, "SELL order price should be the specific hourly open price")
         self.assertAlmostEqual(sell_kwargs['quantity'], qty_bought * self.sample_config['strategy']['sell_asset_percentage'], places=4)
 
-        # Check portfolio state after SELL
-        self.assertIsNone(engine.portfolio['asset_entry_timestamp_utc'])
-        self.assertEqual(engine.portfolio['asset_entry_price'], 0.0)
-        self.assertAlmostEqual(engine.portfolio['asset_qty'], 0, places=4)
 
     @patch(PATCH_PATH_SG)
-    def test_buy_restriction_when_holding_asset(self, MockSignalGenerator):
+    def test_buy_restriction_when_holding_asset(self, MockSignalGenerator): # Needs update for daily data
         mock_sg_instance = MockSignalGenerator.return_value
+        self.sample_config['strategy']['n_day_high_period'] = 1 # Adjusted for simpler daily data
+        self.sample_config['backtesting']['timeframe'] = '1d'
 
-        # Configure to BUY on the first possible signal
-        first_buy_trigger_ts = self.sample_ohlcv_data['timestamp'][self.sample_config['strategy']['n_day_high_period']]
-        first_buy_trigger_dt_utc8 = first_buy_trigger_ts.tz_convert('Asia/Shanghai')
+
+        # Configure to BUY on the first possible signal (2023-01-02)
+        # n_day_high_period = 1, so index 1 (2023-01-02) is first possible buy day
+        first_buy_trigger_daily_ts = self.sample_daily_ohlcv_data['timestamp'][1] # 2023-01-02 00:00:00 UTC
+
+        # Signal generator expects datetime in Asia/Shanghai for its window check
+        first_buy_trigger_dt_utc8 = first_buy_trigger_daily_ts.replace(hour=10).tz_localize('UTC').tz_convert('Asia/Shanghai')
+
 
         def breakout_side_effect(*args, **kwargs):
             dt_utc8 = kwargs.get('current_datetime_utc8')
-            if dt_utc8 == first_buy_trigger_dt_utc8:
-                 # Ensure this time is within buy window for the test config
-                if self.sample_config['strategy']['buy_window_start_time'] <= dt_utc8.strftime("%H:%M") <= self.sample_config['strategy']['buy_window_end_time']:
-                    return "BUY"
+            # Check if the date part matches and if the hour is within the configured buy window
+            if dt_utc8.date() == first_buy_trigger_dt_utc8.date() and \
+               self.sample_config['strategy']['buy_window_start_time'] <= dt_utc8.strftime("%H:%M") <= self.sample_config['strategy']['buy_window_end_time']:
+                return "BUY"
             return None
         mock_sg_instance.check_breakout_signal.side_effect = breakout_side_effect
 
         engine = BacktestingEngine(
             config=self.sample_config,
             data_fetcher=self.mock_data_fetcher,
+            signal_generator=None # Engine will create its own
+        )
+
+        with patch.object(engine, '_simulate_order', wraps=engine._simulate_order) as spy_simulate_order:
+            engine.run_backtest()
+
+        buy_orders = [c for c in spy_simulate_order.call_args_list if c.kwargs.get('order_type') == 'BUY']
+        self.assertEqual(len(buy_orders), 1, "Should only execute one BUY order even if signals persist")
+
+        # Verify check_breakout_signal call count
+        # n_period = 1. Loop starts.
+        # Index 0: current_idx < n_period (0 < 1), no call.
+        # Index 1 (2023-01-02): current_idx >= n_period (1 >= 1). Call check_breakout_signal. BUY signal. Asset bought.
+        # Index 2 (2023-01-03): asset_qty > 0. No call to check_breakout_signal.
+        # Index 3 (2023-01-04): asset_qty > 0 (assuming sell happens later or not at all in this test's scope for buy restriction).
+        # So, check_breakout_signal should be called once.
+        self.assertEqual(mock_sg_instance.check_breakout_signal.call_count, 1)
+
+    @patch(PATCH_PATH_SG)
+    @patch('owl.backtesting_engine.engine.logging') # Patch logging for checking warnings
+    def test_buy_price_fallback_to_daily_if_hourly_missing(self, mock_logging, MockSignalGenerator):
+        mock_sg_instance = MockSignalGenerator.return_value
+        self.sample_config['strategy']['n_day_high_period'] = 1
+        self.sample_config['backtesting']['timeframe'] = '1d'
+
+        # --- Scenario Setup ---
+        # Trigger BUY on 2023-01-02, but ensure no suitable hourly data exists for the buy decision time.
+        buy_trigger_daily_ts_utc = pd.Timestamp('2023-01-02 00:00:00', tz='UTC')
+        buy_decision_time_utc8_hour = 10 # 10:00 UTC+8 (02:00 UTC)
+
+        # Modify hourly data to be missing for the target time
+        # For example, remove all hourly data for 2023-01-02
+        self.sample_hourly_ohlcv_data = self.sample_hourly_ohlcv_data[
+            self.sample_hourly_ohlcv_data['timestamp'].dt.date != pd.Timestamp('2023-01-02').date()
+        ]
+        # Ensure the side effect still uses this modified (emptier) hourly data
+        # The mock_fetch_ohlcv_se in setUp will now return this filtered version for '1h'
+
+        def check_breakout_side_effect_for_fallback(*args, **kwargs):
+            dt_utc8_arg = kwargs.get('current_datetime_utc8')
+            if dt_utc8_arg.date() == pd.Timestamp('2023-01-02').date() and \
+               dt_utc8_arg.hour == buy_decision_time_utc8_hour:
+                return "BUY"
+            return None
+        mock_sg_instance.check_breakout_signal.side_effect = check_breakout_side_effect_for_fallback
+
+        engine = BacktestingEngine(
+            config=self.sample_config,
+            data_fetcher=self.mock_data_fetcher,
             signal_generator=None
         )
 
         with patch.object(engine, '_simulate_order', wraps=engine._simulate_order) as spy_simulate_order:
             engine.run_backtest()
 
-        # Assert that check_breakout_signal was called initially
-        self.assertGreater(mock_sg_instance.check_breakout_signal.call_count, 0)
-        initial_call_count = mock_sg_instance.check_breakout_signal.call_count
-
-        # Count BUY orders
-        buy_orders = [c for c in spy_simulate_order.call_args_list if c.kwargs.get('order_type') == 'BUY']
-        self.assertEqual(len(buy_orders), 1, "Should only execute one BUY order even if signals persist")
-
-        # Further run a few steps to see if check_breakout_signal is still called
-        # This part is tricky because run_backtest consumes the generator.
-        # The core check is that only one BUY order is placed.
-        # The engine logic is: if self.portfolio['asset_qty'] == 0: then check buy signal.
-        # So, after the first buy, asset_qty > 0, and check_breakout_signal should not be called.
-
-        # To verify check_breakout_signal call count properly, we'd need to know exactly when it stops being called.
-        # It's called until a BUY happens. After BUY, asset_qty > 0.
-        # On subsequent candles, the condition self.portfolio['asset_qty'] == 0 fails.
-        # So, check_breakout_signal call count should be number of candles until first BUY (where idx >= n_period)
-
-        first_buy_candle_index = -1
-        for idx, row_ts in enumerate(self.sample_ohlcv_data['timestamp']):
-            if row_ts == first_buy_trigger_ts:
-                first_buy_candle_index = idx
+        # --- Assertions for logging ---
+        fallback_log_found = False
+        for log_call in mock_logging.warning.call_args_list:
+            args, _ = log_call
+            if args and "Falling back to daily close price" in args[0]:
+                fallback_log_found = True
                 break
+        self.assertTrue(fallback_log_found, "Expected fallback warning log was not found.")
 
-        expected_calls_to_check_breakout = first_buy_candle_index - self.sample_config['strategy']['n_day_high_period'] + 1
-        self.assertEqual(mock_sg_instance.check_breakout_signal.call_count, expected_calls_to_check_breakout)
+        # --- Assertions for BUY order ---
+        buy_order_call = None
+        for call_item in spy_simulate_order.call_args_list:
+            if call_item.kwargs.get('order_type') == 'BUY':
+                buy_order_call = call_item
+                break
+        self.assertIsNotNone(buy_order_call, "BUY order was not simulated in fallback test")
+
+        buy_kwargs = buy_order_call.kwargs
+        self.assertEqual(buy_kwargs['timestamp'], buy_trigger_daily_ts_utc)
+
+        # Expected price is the daily close for 2023-01-02
+        expected_daily_close_price = self.sample_daily_ohlcv_data[
+            self.sample_daily_ohlcv_data['timestamp'] == buy_trigger_daily_ts_utc
+        ]['close'].iloc[0] # This is 112
+        self.assertEqual(buy_kwargs['price'], expected_daily_close_price, "BUY order price should be the daily close price due to fallback")
+
+    @patch(PATCH_PATH_SG)
+    @patch('owl.backtesting_engine.engine.logging')
+    def test_sell_price_fallback_to_daily_if_hourly_missing(self, mock_logging, MockSignalGenerator):
+        mock_sg_instance = MockSignalGenerator.return_value
+        self.sample_config['strategy']['n_day_high_period'] = 1
+        self.sample_config['strategy']['holding_period_days'] = 1
+        self.sample_config['backtesting']['timeframe'] = '1d'
+
+        # --- Scenario Setup ---
+        # 1. BUY on 2023-01-02 (using hourly close price as per other test, or daily if that test is separate)
+        buy_trigger_daily_ts_utc = pd.Timestamp('2023-01-02 00:00:00', tz='UTC')
+        buy_decision_time_utc8_hour = 10 # 10:00 UTC+8
+
+        def check_breakout_side_effect_for_buy(*args, **kwargs):
+            dt_utc8_arg = kwargs.get('current_datetime_utc8')
+            if dt_utc8_arg.date() == buy_trigger_daily_ts_utc.date() and \
+               dt_utc8_arg.hour == buy_decision_time_utc8_hour:
+                return "BUY"
+            return None
+        mock_sg_instance.check_breakout_signal.side_effect = check_breakout_side_effect_for_buy
+
+        # 2. Modify hourly data to ensure no hourly candle for SELL decision time
+        # Sell decision: 2023-01-03 (due to holding period 1 day), at 10:00 UTC+8 (02:00 UTC)
+        sell_decision_target_utc = pd.Timestamp('2023-01-03 02:00:00', tz='UTC')
+
+        original_hourly_data = self.sample_hourly_ohlcv_data.copy() # Preserve for other tests
+        self.sample_hourly_ohlcv_data = self.sample_hourly_ohlcv_data[
+            self.sample_hourly_ohlcv_data['timestamp'] < sell_decision_target_utc # Remove candles at or after target
+        ]
+        # The mock_fetch_ohlcv_se in setUp will now use this modified self.sample_hourly_ohlcv_data for this test run.
+
+        engine = BacktestingEngine(
+            config=self.sample_config,
+            data_fetcher=self.mock_data_fetcher,
+            signal_generator=None
+        )
+
+        with patch.object(engine, '_simulate_order', wraps=engine._simulate_order) as spy_simulate_order:
+            engine.run_backtest()
+
+        # Restore hourly data for subsequent tests
+        self.sample_hourly_ohlcv_data = original_hourly_data
+
+        # --- Assertions for logging ---
+        fallback_log_found = False
+        expected_log_message_part = "SELL condition: No hourly candle found at or after"
+        for log_call in mock_logging.warning.call_args_list:
+            args, _ = log_call
+            if args and expected_log_message_part in args[0]:
+                fallback_log_found = True
+                break
+        self.assertTrue(fallback_log_found, f"Expected SELL fallback warning log (containing '{expected_log_message_part}') not found.")
+
+        # --- Assertions for SELL order ---
+        sell_order_call = None
+        for call_item in spy_simulate_order.call_args_list:
+            if call_item.kwargs.get('order_type') == 'SELL':
+                sell_order_call = call_item
+                break
+        self.assertIsNotNone(sell_order_call, "SELL order was not simulated in fallback test")
+
+        sell_kwargs = sell_order_call.kwargs
+
+        # Expected sell order timestamp is the daily candle of 2023-01-03
+        expected_sell_order_daily_ts = pd.Timestamp('2023-01-03 00:00:00', tz='UTC')
+        self.assertEqual(sell_kwargs['timestamp'], expected_sell_order_daily_ts)
+
+        # Expected price is the daily close for 2023-01-03
+        expected_daily_fallback_price = self.sample_daily_ohlcv_data[
+            self.sample_daily_ohlcv_data['timestamp'] == expected_sell_order_daily_ts
+        ]['close'].iloc[0] # Should be 122
+        self.assertEqual(sell_kwargs['price'], expected_daily_fallback_price, "SELL order price should be the daily close price due to fallback")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Updates the backtesting engine's sell logic to use the open price from hourly data for trade execution.

Key changes:
- When a sell condition is met (e.g., holding period expiry), the engine now attempts to use the 'open' price of the first available hourly candle that occurs at or after the sell decision time (typically 10:00 AM Beijing Time on the sell day).
- If suitable hourly data is not found, the system logs a warning and falls back to using the 'close' price of the daily candle for that day.
- The timestamp for recording the sell trade remains the daily candle's timestamp to align with the daily decision-making frequency.
- I have updated the unit tests to verify this new sell pricing mechanism, including the hourly price usage and the daily price fallback.