### PR TITLE
Fix: Adjust buy logic for specific time and price

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,8 @@ okx_password = ""
 n_day_high_period = 7 # Value of N for N-day high breakout strategy
 buy_cash_percentage = 0.8 # Spend 80% of current cash on a BUY signal
 risk_free_rate = 0.0 # Annual risk-free rate for Sharpe Ratio calculation
+buy_window_start_time = "15:00"
+buy_window_end_time = "16:00"
 
 [mode]
 dry_run = true # Set to false for live trading

--- a/owl/signal_generator/generator.py
+++ b/owl/signal_generator/generator.py
@@ -119,21 +119,11 @@ class SignalGenerator:
 
         is_valid_buy_day = day_of_week in [0, 1, 4] # Mon, Tue, Fri
 
-        is_valid_buy_time_window = False
-        if self.buy_window_start_time and self.buy_window_end_time:
-            is_valid_buy_time_window = self.buy_window_start_time <= current_time_utc8 <= self.buy_window_end_time
-        else:
-            logging.warning("SignalGenerator: Buy window start or end time is not properly configured. Buy time check will fail.")
-
         if not is_valid_buy_day:
             print(f"SignalGenerator: Breakout occurred, but today ({current_datetime_utc8.strftime('%A')}) is not a valid buy day (Mon, Tue, Fri).")
             return None
 
-        if not is_valid_buy_time_window:
-            print(f"SignalGenerator: Breakout occurred on a valid day, but current time ({current_datetime_utc8.strftime('%H:%M')}) is not within the configured buy window ({self.buy_window_start_str}-{self.buy_window_end_str}).")
-            return None
-
-        print(f"SignalGenerator: BUY signal generated! Breakout confirmed on a valid buy day ({current_datetime_utc8.strftime('%A')}) and time window ({current_datetime_utc8.strftime('%H:%M')}).")
+        print(f"SignalGenerator: BUY signal generated! Breakout confirmed on a valid buy day ({current_datetime_utc8.strftime('%A')}).")
         return "BUY"
 
 # Example of how to use it (optional, for testing within this file)
@@ -190,7 +180,7 @@ if __name__ == "__main__":
     invalid_time_datetime = datetime(2023, 10, 23, 10, 0, 0) # This is a Monday
     signal_invalid_time = sg.check_breakout_signal(historical_df, current_high_price, invalid_time_datetime)
     logging.info(f"Signal for Scenario 4: {signal_invalid_time}")
-    assert signal_invalid_time is None
+    assert signal_invalid_time == "BUY"
 
     # Scenario 5: Not enough data
     print("\n--- Scenario 5: Not enough historical data ---")

--- a/tests/test_backtesting_engine.py
+++ b/tests/test_backtesting_engine.py
@@ -34,8 +34,8 @@ class TestBacktestingEngineBehavior(unittest.TestCase): # Renamed for broader sc
                 # m_day_low_period, sell_window_start_time, sell_window_end_time removed
                 'sell_asset_percentage': 1.0,
                 'holding_period_days': 1, # Added for new strategy
-                'buy_window_start_time': "09:00",
-                'buy_window_end_time': "17:00",
+                'buy_window_start_time': "09:00", # This can remain, not directly used by price pickup logic
+                'buy_window_end_time': "16:00", # Target buy execution time UTC+8
             },
             'scheduler': {}, # Empty as per previous changes
             'proxy': {}, 'api_keys': {}, 'exchange_settings': {}
@@ -53,19 +53,13 @@ class TestBacktestingEngineBehavior(unittest.TestCase): # Renamed for broader sc
         })
 
         # Hourly data setup
-        # Buy decision time: 2023-01-02 10:00:00 UTC+8 (which is 2023-01-02 02:00:00 UTC)
-        # We need an hourly candle at or before 02:00:00 UTC on Jan 2nd.
-        self.hourly_close_price_for_buy = 111.75 # Specific price to check for the BUY order
+        # Buy decision time (when signal is checked): 2023-01-02 10:00:00 UTC+8 (02:00:00 UTC)
+        # Buy price pickup time (based on buy_window_end_time="16:00"): 2023-01-02 16:00:00 UTC+8 (08:00:00 UTC)
+        self.hourly_open_price_for_buy_at_1600 = 111.88 # New specific price for BUY order
 
         hourly_timestamps_jan1 = pd.date_range(start='2023-01-01 00:00:00', end='2023-01-01 23:00:00', freq='h', tz='UTC')
-        hourly_timestamps_jan2_list = [
-            pd.Timestamp('2023-01-02 00:00:00', tz='UTC'),
-            pd.Timestamp('2023-01-02 01:00:00', tz='UTC'),
-            pd.Timestamp('2023-01-02 02:00:00', tz='UTC'), # This candle will be used for the buy price
-            pd.Timestamp('2023-01-02 03:00:00', tz='UTC')
-        ]
-        hourly_timestamps_jan2 = pd.DatetimeIndex(hourly_timestamps_jan2_list)
-
+        # Generate full hourly data for Jan 2nd to ensure 08:00 UTC is present
+        hourly_timestamps_jan2 = pd.date_range(start='2023-01-02 00:00:00', end='2023-01-02 23:00:00', freq='h', tz='UTC')
         hourly_timestamps_jan3 = pd.date_range(start='2023-01-03 00:00:00', end='2023-01-03 23:00:00', freq='h', tz='UTC')
         hourly_timestamps_jan4 = pd.date_range(start='2023-01-04 00:00:00', end='2023-01-04 00:00:00', freq='h', tz='UTC') # Just one candle for the end date
 
@@ -73,19 +67,33 @@ class TestBacktestingEngineBehavior(unittest.TestCase): # Renamed for broader sc
 
         self.sample_hourly_ohlcv_data = pd.DataFrame({
             'timestamp': all_hourly_timestamps,
-            # Simple ascending values for other columns, will adjust specific close for buy
             'open': [100 + i*0.01 for i in range(len(all_hourly_timestamps))],
             'high': [100.05 + i*0.01 for i in range(len(all_hourly_timestamps))],
             'low': [99.95 + i*0.01 for i in range(len(all_hourly_timestamps))],
-            'close': [100 + i*0.01 for i in range(len(all_hourly_timestamps))],
+            'close': [100 + i*0.01 for i in range(len(all_hourly_timestamps))], # Close prices will be generic, open is targeted
             'volume': [100 + i for i in range(len(all_hourly_timestamps))]
         })
 
-        # Set the specific close for the target buy candle (2023-01-02 02:00:00 UTC)
-        target_hourly_buy_candle_time = pd.Timestamp('2023-01-02 02:00:00', tz='UTC')
-        self.sample_hourly_ohlcv_data.loc[self.sample_hourly_ohlcv_data['timestamp'] == target_hourly_buy_candle_time, 'close'] = self.hourly_close_price_for_buy
+        # Set the specific OPEN for the target BUY candle (2023-01-02 08:00:00 UTC, which is 16:00 UTC+8)
+        target_buy_price_pickup_utc = pd.Timestamp('2023-01-02 08:00:00', tz='UTC')
+        if target_buy_price_pickup_utc in self.sample_hourly_ohlcv_data['timestamp'].values:
+            self.sample_hourly_ohlcv_data.loc[self.sample_hourly_ohlcv_data['timestamp'] == target_buy_price_pickup_utc, 'open'] = self.hourly_open_price_for_buy_at_1600
+        else:
+            # This else block should ideally not be needed if hourly_timestamps_jan2 covers the full day
+            new_buy_price_row = pd.DataFrame([{
+                'timestamp': target_buy_price_pickup_utc,
+                'open': self.hourly_open_price_for_buy_at_1600,
+                'high': 112, 'low': 111, 'close': 111.90, 'volume': 50
+            }])
+            self.sample_hourly_ohlcv_data = pd.concat([self.sample_hourly_ohlcv_data, new_buy_price_row])
 
-        # Set the specific open for the target sell candle (2023-01-03 02:00:00 UTC)
+        # Old setup for hourly_close_price_for_buy (at 02:00 UTC) is no longer primary for buy price.
+        # self.hourly_close_price_for_buy = 111.75
+        # target_hourly_buy_candle_time = pd.Timestamp('2023-01-02 02:00:00', tz='UTC')
+        # self.sample_hourly_ohlcv_data.loc[self.sample_hourly_ohlcv_data['timestamp'] == target_hourly_buy_candle_time, 'close'] = self.hourly_close_price_for_buy
+
+
+        # Set the specific open for the target SELL candle (2023-01-03 02:00:00 UTC which is 10:00 UTC+8)
         self.hourly_open_price_for_sell = 120.25
         target_hourly_sell_candle_time = pd.Timestamp('2023-01-03 02:00:00', tz='UTC')
         if target_hourly_sell_candle_time in self.sample_hourly_ohlcv_data['timestamp'].values:
@@ -133,14 +141,15 @@ class TestBacktestingEngineBehavior(unittest.TestCase): # Renamed for broader sc
         self.sample_config['backtesting']['timeframe'] = '1d' # Ensure engine knows main timeframe is daily
 
         # --- Scenario Setup ---
-        # Buy on 2023-01-02. Daily high is 115. Previous day (2023-01-01) high is 105. Breakout.
-        # Buy decision time: 2023-01-02 10:00:00 UTC+8 (which is 02:00:00 UTC)
-        # Expected hourly candle for price: 2023-01-02 02:00:00 UTC, close = self.hourly_close_price_for_buy (111.75)
-        # Daily candle timestamp for trade record: 2023-01-02 00:00:00 UTC
+        # Buy signal on 2023-01-02 (daily candle). Daily high 115 > prev daily high 105.
+        # SignalGenerator check_breakout_signal is called with current_datetime_utc8 = 2023-01-02 10:00:00 UTC+8.
+        # BacktestingEngine then uses 'buy_window_end_time' ("16:00" UTC+8) from config to find price.
+        # Target hourly candle for BUY price: 2023-01-02 16:00:00 UTC+8 (which is 08:00:00 UTC).
+        # Expected BUY price: self.hourly_open_price_for_buy_at_1600 (111.88).
+        # Daily candle timestamp for trade record: 2023-01-02 00:00:00 UTC.
 
         buy_trigger_daily_ts_utc = pd.Timestamp('2023-01-02 00:00:00', tz='UTC')
-        buy_decision_time_utc8_hour = 10 # 10:00 UTC+8
-        # expected_hourly_pickup_time_utc = pd.Timestamp(f'2023-01-02 {buy_decision_time_utc8_hour-8:02d}:00:00', tz='UTC') # 02:00 UTC for the hourly candle
+        buy_decision_time_utc8_hour = 10 # 10:00 UTC+8 (This is when signal is checked based on daily data)
 
         # Expected sell day: holding_period_days = 1. Buy on Jan 2. Sell on Jan 3 at 10:00 Beijing Time.
         sell_day_utc = pd.Timestamp('2023-01-03 00:00:00', tz='UTC')
@@ -201,7 +210,7 @@ class TestBacktestingEngineBehavior(unittest.TestCase): # Renamed for broader sc
 
         buy_kwargs = buy_order_call.kwargs
         self.assertEqual(buy_kwargs['timestamp'], buy_trigger_daily_ts_utc, "BUY order timestamp should be the daily candle's timestamp")
-        self.assertEqual(buy_kwargs['price'], self.hourly_close_price_for_buy, "BUY order price should be the specific hourly close")
+        self.assertEqual(buy_kwargs['price'], self.hourly_open_price_for_buy_at_1600, "BUY order price should be the hourly OPEN price at 16:00 UTC+8 target")
 
         qty_bought = buy_kwargs['quantity']
 
@@ -267,7 +276,142 @@ class TestBacktestingEngineBehavior(unittest.TestCase): # Renamed for broader sc
         # Index 2 (2023-01-03): asset_qty > 0. No call to check_breakout_signal.
         # Index 3 (2023-01-04): asset_qty > 0 (assuming sell happens later or not at all in this test's scope for buy restriction).
         # So, check_breakout_signal should be called once.
-        self.assertEqual(mock_sg_instance.check_breakout_signal.call_count, 1)
+        # Simplified breakout_side_effect:
+        # The original side effect was:
+        # if dt_utc8.date() == first_buy_trigger_dt_utc8.date() and \
+        #    self.sample_config['strategy']['buy_window_start_time'] <= dt_utc8.strftime("%H:%M") <= self.sample_config['strategy']['buy_window_end_time']:
+        # This was already good as SignalGenerator itself doesn't do window check, but the mock was too specific.
+        # The actual check_breakout_signal call from engine uses current_datetime_utc8 derived from daily candle + fixed hour.
+        # The mock should just confirm it's the right day and hour for the *signal detection point*.
+
+        # Re-check call count logic:
+        # n_period = 1.
+        # Daily loop:
+        # idx 0 (2023-01-01): current_idx (0) < n_period (1). No call.
+        # idx 1 (2023-01-02): current_idx (1) >= n_period (1). Call. BUY. Asset bought.
+        # idx 2 (2023-01-03): asset_qty > 0. No call. (Sell logic might run, but no buy signal check)
+        # idx 3 (2023-01-04): asset_qty > 0 or 0 if sold. If 0, would call again.
+        # If holding_period_days = 1, sell happens on Jan 3.
+        # So on Jan 4, asset_qty would be 0. check_breakout_signal would be called.
+        # Let's adjust holding_period_days for this test to ensure asset is still held.
+        # Or, simplify the side effect to only fire once.
+
+        # For this test, the key is that *after a buy*, subsequent buy signals on other days (if they occurred) are ignored.
+        # The current side effect fires on 2023-01-02 10:00 UTC+8.
+        # If it fired again on 2023-01-03 10:00 UTC+8 and we still held asset, it would be ignored.
+        # If we sold on 2023-01-03, then on 2023-01-04, a new BUY signal would be processed.
+        # The current assertion of 1 call is correct IF the test ensures asset is held for the remainder.
+        # With holding_period_days=1, buy on Jan 2, sell on Jan 3.
+        # So on Jan 4, check_breakout_signal IS called.
+        # Let's make the side_effect only return "BUY" for the first relevant call.
+
+        # Redefine side effect for test_buy_restriction_when_holding_asset
+        # Ensure it only returns "BUY" once for the intended buy day.
+
+        # Store the original side_effect if it was more complex, or just redefine:
+        # The original `breakout_side_effect` was:
+        # if dt_utc8.date() == first_buy_trigger_dt_utc8.date() and \
+        #    self.sample_config['strategy']['buy_window_start_time'] <= dt_utc8.strftime("%H:%M") <= self.sample_config['strategy']['buy_window_end_time']:
+        # This is fine, as the signal is checked at a specific time (10:00 UTC+8 in the test).
+        # The SignalGenerator itself doesn't use the window for its internal logic anymore.
+        # The number of calls to check_breakout_signal will be:
+        # Day 1 (idx 0): No (n_period)
+        # Day 2 (idx 1): Yes. BUY.
+        # Day 3 (idx 2): No (asset held). Sell happens based on holding period (e.g. 10:00 UTC+8).
+        # Day 4 (idx 3): Yes (asset sold).
+        # So, check_breakout_signal.call_count would be 2 if it runs to Day 4 and sells on Day 3.
+        # The test's end_date is '2023-01-04'.
+        # Daily data: 01-01, 01-02, 01-03, 01-04.
+        # Buy on 01-02. Sell on 01-03 (holding period 1 day).
+        # On 01-04, portfolio is empty, so check_breakout_signal is called.
+        self.assertEqual(mock_sg_instance.check_breakout_signal.call_count, 2, "check_breakout_signal should be called on 2023-01-02 and 2023-01-04")
+
+
+    @patch(PATCH_PATH_SG)
+    @patch('owl.backtesting_engine.engine.logging')
+    def test_buy_price_fallback_to_next_available_hourly_candle(self, mock_logging, MockSignalGenerator):
+        mock_sg_instance = MockSignalGenerator.return_value
+        self.sample_config['strategy']['n_day_high_period'] = 1
+        self.sample_config['strategy']['buy_window_end_time'] = "16:00" # Explicitly set for clarity
+
+        buy_trigger_daily_ts_utc = pd.Timestamp('2023-01-02 00:00:00', tz='UTC')
+        # Target buy time: 2023-01-02 16:00 UTC+8 -> 08:00 UTC
+        exact_target_hourly_utc = pd.Timestamp('2023-01-02 08:00:00', tz='UTC')
+        # Fallback hourly candle: 2023-01-02 09:00 UTC
+        fallback_hourly_candle_utc = pd.Timestamp('2023-01-02 09:00:00', tz='UTC')
+        expected_fallback_hourly_open_price = 111.55
+
+        # Modify hourly data for this test
+        original_hourly_data_in_setup = self.sample_hourly_ohlcv_data.copy() # Preserve data from setUp
+        temp_hourly_data = self.sample_hourly_ohlcv_data.copy()
+
+        # Ensure exact target is missing
+        temp_hourly_data = temp_hourly_data[temp_hourly_data['timestamp'] != exact_target_hourly_utc]
+
+        # Ensure fallback candle exists and has the target open price
+        if fallback_hourly_candle_utc in temp_hourly_data['timestamp'].values:
+            temp_hourly_data.loc[temp_hourly_data['timestamp'] == fallback_hourly_candle_utc, 'open'] = expected_fallback_hourly_open_price
+        else:
+            new_fallback_row = pd.DataFrame([{
+                'timestamp': fallback_hourly_candle_utc, 'open': expected_fallback_hourly_open_price,
+                'high': 112, 'low': 111, 'close': 111.60, 'volume': 60 # Example values
+            }])
+            temp_hourly_data = pd.concat([temp_hourly_data, new_fallback_row]).sort_values('timestamp').reset_index(drop=True)
+
+        # Update DataFetcher mock to use this temporary hourly data
+        def temp_mock_fetch_ohlcv_se(symbol, timeframe, since, limit=None, params=None):
+            if timeframe == '1d':
+                daily_data_copy = self.sample_daily_ohlcv_data.copy()
+                if since is not None:
+                    since_ts = pd.Timestamp(since, unit='ms', tz='UTC')
+                    daily_data_copy = daily_data_copy[daily_data_copy['timestamp'] >= since_ts.normalize()]
+                return daily_data_copy
+            elif timeframe == '1h':
+                hourly_data_copy = temp_hourly_data.copy() # Use the modified data
+                if since is not None:
+                    since_ts = pd.Timestamp(since, unit='ms', tz='UTC')
+                    hourly_data_copy = hourly_data_copy[hourly_data_copy['timestamp'] >= since_ts]
+                return hourly_data_copy
+            return pd.DataFrame()
+
+        original_fetch_side_effect = self.mock_data_fetcher.fetch_ohlcv.side_effect
+        self.mock_data_fetcher.fetch_ohlcv.side_effect = temp_mock_fetch_ohlcv_se
+
+        # Mock SignalGenerator's check_breakout_signal
+        buy_decision_time_utc8_hour = 10 # When signal is detected on daily data
+        def check_breakout_side_effect(*args, **kwargs):
+            dt_utc8_arg = kwargs.get('current_datetime_utc8')
+            if dt_utc8_arg.date() == buy_trigger_daily_ts_utc.date() and dt_utc8_arg.hour == buy_decision_time_utc8_hour:
+                return "BUY"
+            return None
+        mock_sg_instance.check_breakout_signal.side_effect = check_breakout_side_effect
+
+        engine = BacktestingEngine(config=self.sample_config, data_fetcher=self.mock_data_fetcher, signal_generator=None)
+
+        with patch.object(engine, '_simulate_order', wraps=engine._simulate_order) as spy_simulate_order:
+            engine.run_backtest()
+
+        # Restore original side effect for DataFetcher and hourly data for other tests
+        self.mock_data_fetcher.fetch_ohlcv.side_effect = original_fetch_side_effect
+        self.sample_hourly_ohlcv_data = original_hourly_data_in_setup # Restore for other tests that rely on setUp's version
+
+        # Assertions
+        buy_order_call = next((c for c in spy_simulate_order.call_args_list if c.kwargs.get('order_type') == 'BUY'), None)
+        self.assertIsNotNone(buy_order_call, "BUY order was not simulated")
+
+        buy_kwargs = buy_order_call.kwargs
+        self.assertEqual(buy_kwargs['price'], expected_fallback_hourly_open_price,
+                         "BUY order price should be the open of the next available hourly candle")
+        self.assertEqual(buy_kwargs['timestamp'], buy_trigger_daily_ts_utc,
+                         "BUY order timestamp should be the daily candle's timestamp")
+
+        # Check for logging
+        log_found = any(
+            "BUY signal: Using alternative HOURLY OPEN price" in call_args[0][0]
+            for call_args in mock_logging.info.call_args_list
+        )
+        self.assertTrue(log_found, "Expected log for fallback to alternative hourly candle not found.")
+
 
     @patch(PATCH_PATH_SG)
     @patch('owl.backtesting_engine.engine.logging') # Patch logging for checking warnings
@@ -283,16 +427,37 @@ class TestBacktestingEngineBehavior(unittest.TestCase): # Renamed for broader sc
 
         # Modify hourly data to be missing for the target time
         # For example, remove all hourly data for 2023-01-02
-        self.sample_hourly_ohlcv_data = self.sample_hourly_ohlcv_data[
-            self.sample_hourly_ohlcv_data['timestamp'].dt.date != pd.Timestamp('2023-01-02').date()
+        # To ensure this test is independent and doesn't affect others, copy and modify.
+        original_hourly_data_in_setup = self.sample_hourly_ohlcv_data.copy()
+        temp_hourly_data_for_this_test = self.sample_hourly_ohlcv_data.copy()
+        temp_hourly_data_for_this_test = temp_hourly_data_for_this_test[
+            temp_hourly_data_for_this_test['timestamp'].dt.date != pd.Timestamp('2023-01-02').date()
         ]
-        # Ensure the side effect still uses this modified (emptier) hourly data
-        # The mock_fetch_ohlcv_se in setUp will now return this filtered version for '1h'
+
+        # Update DataFetcher mock to use this temporary hourly data for this test only
+        def temp_fetch_ohlcv_for_daily_fallback(symbol, timeframe, since, limit=None, params=None):
+            if timeframe == '1d':
+                daily_data_copy = self.sample_daily_ohlcv_data.copy()
+                if since is not None:
+                    since_ts = pd.Timestamp(since, unit='ms', tz='UTC')
+                    daily_data_copy = daily_data_copy[daily_data_copy['timestamp'] >= since_ts.normalize()]
+                return daily_data_copy
+            elif timeframe == '1h':
+                hourly_data_copy = temp_hourly_data_for_this_test.copy() # Use the specific modified data
+                if since is not None:
+                    since_ts = pd.Timestamp(since, unit='ms', tz='UTC')
+                    hourly_data_copy = hourly_data_copy[hourly_data_copy['timestamp'] >= since_ts]
+                return hourly_data_copy
+            return pd.DataFrame()
+
+        original_fetch_side_effect = self.mock_data_fetcher.fetch_ohlcv.side_effect
+        self.mock_data_fetcher.fetch_ohlcv.side_effect = temp_fetch_ohlcv_for_daily_fallback
+
 
         def check_breakout_side_effect_for_fallback(*args, **kwargs):
             dt_utc8_arg = kwargs.get('current_datetime_utc8')
             if dt_utc8_arg.date() == pd.Timestamp('2023-01-02').date() and \
-               dt_utc8_arg.hour == buy_decision_time_utc8_hour:
+               dt_utc8_arg.hour == buy_decision_time_utc8_hour: # buy_decision_time_utc8_hour is 10
                 return "BUY"
             return None
         mock_sg_instance.check_breakout_signal.side_effect = check_breakout_side_effect_for_fallback
@@ -305,6 +470,11 @@ class TestBacktestingEngineBehavior(unittest.TestCase): # Renamed for broader sc
 
         with patch.object(engine, '_simulate_order', wraps=engine._simulate_order) as spy_simulate_order:
             engine.run_backtest()
+
+        # Restore original fetch side effect and sample_hourly_ohlcv_data
+        self.mock_data_fetcher.fetch_ohlcv.side_effect = original_fetch_side_effect
+        self.sample_hourly_ohlcv_data = original_hourly_data_in_setup
+
 
         # --- Assertions for logging ---
         fallback_log_found = False


### PR DESCRIPTION
This commit addresses an issue where the buy signal's time window check was always failing due to the backtesting engine passing a fixed daily timestamp (08:00 UTC+8) to the signal generator. Additionally, it refines the buy execution to target a specific price point.

Changes:

1.  **SignalGenerator (`owl/signal_generator/generator.py`):**
    *   Removed the `is_valid_buy_time_window` check from the
        `check_breakout_signal` method. The signal now only depends on
        a valid breakout and a valid buy day.
    *   Updated inline tests (Scenario 4) to reflect that signals can
        be generated on valid days regardless of the input time if a
        breakout occurs.

2.  **BacktestingEngine (`owl/backtesting_engine/engine.py`):**
    *   Modified the buy logic when a "BUY" signal is received:
        *   It now targets the `buy_window_end_time` (from strategy config,
            e.g., "16:00") on the day the signal is generated.
        *   It attempts to use the **open price** of the hourly candle
            at this specific UTC+8 time.
        *   Fallbacks:
            1.  If the exact hourly candle is missing, it uses the open
                price of the next available hourly candle on the same day.
            2.  If no suitable hourly candle is found on that day, it
                falls back to the daily close price.
    *   Updated logging to provide clarity on which price was used.

3.  **Configuration (`config.toml`):**
    *   Added `buy_window_start_time` ("15:00") and `buy_window_end_time`
        ("16:00") to the `[strategy]` section to provide the necessary
        parameters for the new buy logic.

4.  **Tests (`tests/test_backtesting_engine.py`):**
    *   Updated `test_buy_and_sell_trade_execution_with_hourly_buy_price`
        to assert buying at the hourly 'open' price based on
        `buy_window_end_time`.
    *   Confirmed `test_buy_price_fallback_to_daily_if_hourly_missing`
        remains valid.
    *   Added a new test
        `test_buy_price_fallback_to_next_available_hourly_candle` to
        cover the first-level hourly fallback.
    *   Adjusted assertions in `test_buy_restriction_when_holding_asset`.

This resolves the issue by decoupling the signal generation time check from the actual buy execution time and price, allowing for more precise trade simulation as per strategy requirements.